### PR TITLE
fix upload Gzipped file to S3 issue

### DIFF
--- a/census-salt/generation/src/main/scala/software/uncharted/censushackathon2016/S3Uploader.scala
+++ b/census-salt/generation/src/main/scala/software/uncharted/censushackathon2016/S3Uploader.scala
@@ -24,8 +24,8 @@ class S3Uploader(accessKey: String, secretKey: String, bucket: String, keyPrefix
     val bos = new ByteArrayOutputStream(bytes.length)
     val os = new GZIPOutputStream(bos)
     try {
-      os.write(bytes)
-
+      os.write(bytes, 0, bytes.length)
+      os.close()
       val is = new ByteArrayInputStream(bos.toByteArray())
       val meta = new ObjectMetadata()
 
@@ -40,7 +40,6 @@ class S3Uploader(accessKey: String, secretKey: String, bucket: String, keyPrefix
 
       is.close()
     } finally {
-      os.close()
       bos.close()
     }
     keyName


### PR DESCRIPTION
Fixed Upload to S3 Issue where json files could not be opened and read due to file corruption